### PR TITLE
Fix for files > 2^31 bytes

### DIFF
--- a/src/tail.cpp
+++ b/src/tail.cpp
@@ -132,12 +132,12 @@ void Tail::OnEvent(uv_fs_event_t* handle, const char* filename, int events, int 
     
     tail_instance->ontail = true;
     
-	int length = 0;
-    int position = 0;
+    file_position_type length = 0;
+    file_position_type position = 0;
     char *buffer;
     
     ifstream fp(handle->filename, ios::binary);
-    int line_length;
+    file_position_type line_length;
     
     fp.seekg(0, ios::end);
     position = fp.tellg();

--- a/src/tail.h
+++ b/src/tail.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <fstream>
+#include <stdint.h>
 
 #include <v8.h> // v8 is the Javascript engine used by Node
 #include <node.h>
@@ -30,14 +31,15 @@ private:
     uv_fs_event_t _event_handle;
     
     static void OnEvent(uv_fs_event_t* handle, const char* filename, int events, int status);
-        
+
+    typedef int64_t file_position_type;
 public:
         
     bool ontail;
     
     string separator;
     
-    int last_position;
+    file_position_type last_position;
     
 	void Emit(Handle<String> event, int argc, Handle<Value> argv[]);
 		
@@ -51,3 +53,4 @@ public:
 	
 	static Handle<Value> close(const Arguments& args);
 };
+


### PR DESCRIPTION
Use int64_t instead of int to be able to tail also files > 2^31 bytes. stdint.h should be available on all recent platforms.
